### PR TITLE
MPIR-365 Upgrade keytool-maven-plugin to 1.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -428,7 +428,7 @@ under the License.
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>keytool-maven-plugin</artifactId>
-          <version>1.0</version>
+          <version>1.5</version>
           <configuration>
             <keystore>${basedir}/target/jetty.jks</keystore>
             <dname>cn=jetty, ou=jetty, L=Unknown, ST=Unknown, o=Apache, c=Unknown</dname>
@@ -478,7 +478,7 @@ under the License.
             <phase>initialize</phase>
             <goals>
               <goal>clean</goal>
-              <goal>genkey</goal>
+              <goal>generateKeyPair</goal>
             </goals>
           </execution>
         </executions>


### PR DESCRIPTION
Fixes problem with keytool run for Java 9 on Windows/Linux