### PR TITLE
[MPIR-386] Add plugin repositories to project building requests

### DIFF
--- a/src/main/java/org/apache/maven/report/projectinfo/AbstractProjectInfoReport.java
+++ b/src/main/java/org/apache/maven/report/projectinfo/AbstractProjectInfoReport.java
@@ -133,6 +133,14 @@ public abstract class AbstractProjectInfoReport
     protected List<ArtifactRepository> remoteRepositories;
 
     /**
+     * Plugin repositories used for the project.
+     *
+     * @since 3.0.2
+     */
+    @Parameter( property = "project.pluginArtifactRepositories" )
+    protected List<ArtifactRepository> pluginRepositories;
+
+    /**
      * The reactor projects.
      *
      * @since 2.10

--- a/src/main/java/org/apache/maven/report/projectinfo/DependenciesReport.java
+++ b/src/main/java/org/apache/maven/report/projectinfo/DependenciesReport.java
@@ -142,6 +142,7 @@ public class DependenciesReport
             new DefaultProjectBuildingRequest( getSession().getProjectBuildingRequest() );
         buildingRequest.setLocalRepository( localRepository );
         buildingRequest.setRemoteRepositories( remoteRepositories );
+        buildingRequest.setPluginArtifactRepositories( pluginRepositories );
 
         RepositoryUtils repoUtils =
             new RepositoryUtils( getLog(), projectBuilder, repositorySystem, resolver,

--- a/src/main/java/org/apache/maven/report/projectinfo/DependencyManagementReport.java
+++ b/src/main/java/org/apache/maven/report/projectinfo/DependencyManagementReport.java
@@ -94,6 +94,7 @@ public class DependencyManagementReport
             new DefaultProjectBuildingRequest( getSession().getProjectBuildingRequest() );
         buildingRequest.setLocalRepository( localRepository );
         buildingRequest.setRemoteRepositories( remoteRepositories );
+        buildingRequest.setPluginArtifactRepositories( pluginRepositories );
         
         RepositoryUtils repoUtils =
             new RepositoryUtils( getLog(), projectBuilder, repositorySystem, resolver,

--- a/src/test/java/org/apache/maven/report/projectinfo/AbstractProjectInfoTestCase.java
+++ b/src/test/java/org/apache/maven/report/projectinfo/AbstractProjectInfoTestCase.java
@@ -187,8 +187,8 @@ public abstract class AbstractProjectInfoTestCase
         repoSession.setLocalRepositoryManager( new SimpleLocalRepositoryManager( artifactStubFactory.getWorkingDir() ) );
 
         setVariableValueToObject( mojo, "session", legacySupport.getSession() );
-
         setVariableValueToObject( mojo, "remoteRepositories", mojo.getProject().getRemoteArtifactRepositories() );
+        setVariableValueToObject( mojo, "pluginRepositories", mojo.getProject().getPluginArtifactRepositories() );
         return mojo;
     }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/MPIR-386

When the `central` pluginRepository is overridden in the POM, failing to set the pluginRepositories can lead to some failures resolving plugins along with their dependencies/extensions.