### PR TITLE
Fixed [MPIR-405] regression in the maven site rendering

### DIFF
--- a/src/main/java/org/apache/maven/report/projectinfo/DependencyConvergenceReport.java
+++ b/src/main/java/org/apache/maven/report/projectinfo/DependencyConvergenceReport.java
@@ -692,22 +692,18 @@ public class DependencyConvergenceReport
 
     private void iconSuccess( Locale locale, Sink sink )
     {
-        sink.figure();
-        sink.figureCaption();
-        sink.text( getI18nString( locale, "icon.success" ) );
-        sink.figureCaption_();
+        // a rendering regression was fixed here,
+        // putting figure back will reintroduce the regression.
+        // https://issues.apache.org/jira/browse/MPIR-405
         sink.figureGraphics( IMG_SUCCESS_URL );
-        sink.figure_();
     }
 
     private void iconError( Locale locale, Sink sink )
     {
-        sink.figure();
-        sink.figureCaption();
-        sink.text( getI18nString( locale, "icon.error" ) );
-        sink.figureCaption_();
+        // a rendering regression was fixed here,
+        // putting figure back will reintroduce the regression.
+        // https://issues.apache.org/jira/browse/MPIR-405
         sink.figureGraphics( IMG_ERROR_URL );
-        sink.figure_();
     }
 
     /**

--- a/src/main/java/org/apache/maven/report/projectinfo/DependencyConvergenceReport.java
+++ b/src/main/java/org/apache/maven/report/projectinfo/DependencyConvergenceReport.java
@@ -692,12 +692,16 @@ public class DependencyConvergenceReport
 
     private void iconSuccess( Locale locale, Sink sink )
     {
-        sink.figureGraphics( IMG_SUCCESS_URL );
+        SinkEventAttributes attributes =
+            new SinkEventAttributeSet( SinkEventAttributes.ALT, getI18nString( locale, "icon.success" ) );
+        sink.figureGraphics( IMG_SUCCESS_URL, attributes );
     }
 
     private void iconError( Locale locale, Sink sink )
     {
-        sink.figureGraphics( IMG_ERROR_URL );
+        SinkEventAttributes attributes =
+            new SinkEventAttributeSet( SinkEventAttributes.ALT, getI18nString( locale, "icon.error" ) );
+        sink.figureGraphics( IMG_ERROR_URL, attributes );
     }
 
     /**

--- a/src/main/java/org/apache/maven/report/projectinfo/DependencyConvergenceReport.java
+++ b/src/main/java/org/apache/maven/report/projectinfo/DependencyConvergenceReport.java
@@ -692,17 +692,11 @@ public class DependencyConvergenceReport
 
     private void iconSuccess( Locale locale, Sink sink )
     {
-        // a rendering regression was fixed here,
-        // putting figure back will reintroduce the regression.
-        // https://issues.apache.org/jira/browse/MPIR-405
         sink.figureGraphics( IMG_SUCCESS_URL );
     }
 
     private void iconError( Locale locale, Sink sink )
     {
-        // a rendering regression was fixed here,
-        // putting figure back will reintroduce the regression.
-        // https://issues.apache.org/jira/browse/MPIR-405
         sink.figureGraphics( IMG_ERROR_URL );
     }
 

--- a/src/main/java/org/apache/maven/report/projectinfo/dependencies/renderer/DependenciesRenderer.java
+++ b/src/main/java/org/apache/maven/report/projectinfo/dependencies/renderer/DependenciesRenderer.java
@@ -489,29 +489,14 @@ public class DependenciesRenderer
         endSection();
     }
 
-    /**
-     * Internal Artifact comparator
-     */
-    class ArtifactComparator
-          implements Comparator<Artifact>
-    {
-        /** {@inheritDoc} */
-        public int compare( Artifact p1, Artifact p2 )
-        {
-            return String.CASE_INSENSITIVE_ORDER.compare(
-                  dependencies.getFile( p1 ).getName(),
-                  dependencies.getFile( p2 ).getName() );
-        }
-    }
-
     private void renderSectionDependencyFileDetails()
     {
         startSection( getI18nString( "file.details.title" ) );
 
         List<Artifact> alldeps = dependencies.getAllDependencies();
+        Collections.sort( alldeps, getArtifactComparator() );
 
         resolveAtrifacts( alldeps );
-        Collections.sort( alldeps, new ArtifactComparator() );
 
         // i18n
         String filename = getI18nString( "file.details.column.file" );
@@ -849,19 +834,6 @@ public class DependenciesRenderer
         tableRow( withOptional, content );
     }
 
-    /**
-     * Internal DependencyNode comparator
-     */
-    static class DependencyNodeComparator
-          implements Comparator<DependencyNode>
-    {
-        /** {@inheritDoc} */
-        public int compare( DependencyNode p1, DependencyNode p2 )
-        {
-            return p1.getArtifact().getId().compareTo( p2.getArtifact().getId() );
-        }
-    }
-
     private void printDependencyListing( DependencyNode node )
     {
         Artifact artifact = node.getArtifact();
@@ -898,7 +870,6 @@ public class DependenciesRenderer
             if ( toBeIncluded )
             {
                 sink.list();
-                Collections.sort( subList, new DependencyNodeComparator() );
                 for ( DependencyNode dep : subList )
                 {
                     printDependencyListing( dep );

--- a/src/main/java/org/apache/maven/report/projectinfo/dependencies/renderer/DependenciesRenderer.java
+++ b/src/main/java/org/apache/maven/report/projectinfo/dependencies/renderer/DependenciesRenderer.java
@@ -489,14 +489,29 @@ public class DependenciesRenderer
         endSection();
     }
 
+    /**
+     * Internal Artifact comparator
+     */
+    class ArtifactComparator
+          implements Comparator<Artifact>
+    {
+        /** {@inheritDoc} */
+        public int compare( Artifact p1, Artifact p2 )
+        {
+            return String.CASE_INSENSITIVE_ORDER.compare(
+                  dependencies.getFile( p1 ).getName(),
+                  dependencies.getFile( p2 ).getName() );
+        }
+    }
+
     private void renderSectionDependencyFileDetails()
     {
         startSection( getI18nString( "file.details.title" ) );
 
         List<Artifact> alldeps = dependencies.getAllDependencies();
-        Collections.sort( alldeps, getArtifactComparator() );
 
         resolveAtrifacts( alldeps );
+        Collections.sort( alldeps, new ArtifactComparator() );
 
         // i18n
         String filename = getI18nString( "file.details.column.file" );
@@ -834,6 +849,19 @@ public class DependenciesRenderer
         tableRow( withOptional, content );
     }
 
+    /**
+     * Internal DependencyNode comparator
+     */
+    static class DependencyNodeComparator
+          implements Comparator<DependencyNode>
+    {
+        /** {@inheritDoc} */
+        public int compare( DependencyNode p1, DependencyNode p2 )
+        {
+            return p1.getArtifact().getId().compareTo( p2.getArtifact().getId() );
+        }
+    }
+
     private void printDependencyListing( DependencyNode node )
     {
         Artifact artifact = node.getArtifact();
@@ -870,6 +898,7 @@ public class DependenciesRenderer
             if ( toBeIncluded )
             {
                 sink.list();
+                Collections.sort( subList, new DependencyNodeComparator() );
                 for ( DependencyNode dep : subList )
                 {
                     printDependencyListing( dep );


### PR DESCRIPTION
https://issues.apache.org/jira/browse/MPIR-405

Maven Site Plugin and Doxia switching to HTML 5 broke all the reports that includes images.
Including other report plugins.
The proposed fix allows to return back to the original compact format that was more synthetic.
