### PR TITLE
[MPIR-412] Fix dependency report tag balance when exception

### DIFF
--- a/src/it/MPIR-412/invoker.properties
+++ b/src/it/MPIR-412/invoker.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.goals = ${project.groupId}:${project.artifactId}:${project.version}:dependencies

--- a/src/it/MPIR-412/pom.xml
+++ b/src/it/MPIR-412/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.plugins.project-info-reports.its</groupId>
+  <artifactId>MPIR-412</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+  <url>http://maven.apache.org/plugins/it/${project.artifactId}</url>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+  </properties>
+
+  <dependencies>
+    <!-- an example of a dependency with a problematic POM --> 
+    <dependency>
+      <groupId>xml-apis</groupId>
+      <artifactId>xml-apis-ext</artifactId>
+      <version>1.3.04</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-project-info-reports-plugin</artifactId>
+        <version>@pom.version@</version>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/src/it/MPIR-412/verify.groovy
+++ b/src/it/MPIR-412/verify.groovy
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// should be able to parse the output as XML
+parser = new XmlParser();
+parser.setFeature('http://apache.org/xml/features/disallow-doctype-decl', false);
+result = parser.parse(new File(basedir, 'target/site/dependencies.html'));
+assert result instanceof Node;

--- a/src/main/java/org/apache/maven/report/projectinfo/dependencies/renderer/DependenciesRenderer.java
+++ b/src/main/java/org/apache/maven/report/projectinfo/dependencies/renderer/DependenciesRenderer.java
@@ -889,8 +889,6 @@ public class DependenciesRenderer
 
         sink.rawText( "<div id=\"" + uid + "\" style=\"display:none\">" );
 
-        sink.table();
-
         if ( !Artifact.SCOPE_SYSTEM.equals( artifact.getScope() ) )
         {
             try
@@ -901,6 +899,8 @@ public class DependenciesRenderer
                 String artifactName = artifactProject.getName();
 
                 List<License> licenses = artifactProject.getLicenses();
+
+                sink.table();
 
                 sink.tableRow();
                 sink.tableHeaderCell();
@@ -989,6 +989,11 @@ public class DependenciesRenderer
                     licenseMap.put( unknownLicenseMessage, artifactName );
                 }
                 sink.paragraph_();
+
+                sink.tableCell_();
+                sink.tableRow_();
+
+                sink.table_();
             }
             catch ( ProjectBuildingException e )
             {
@@ -1006,6 +1011,8 @@ public class DependenciesRenderer
         }
         else
         {
+            sink.table();
+
             sink.tableRow();
             sink.tableHeaderCell();
             sink.text( id );
@@ -1031,12 +1038,12 @@ public class DependenciesRenderer
                 sink.text( artifact.getFile().getAbsolutePath() );
                 sink.paragraph_();
             }
+
+            sink.tableCell_();
+            sink.tableRow_();
+
+            sink.table_();
         }
-
-        sink.tableCell_();
-        sink.tableRow_();
-
-        sink.table_();
 
         sink.rawText( "</div>" );
     }


### PR DESCRIPTION
Make sure that open and close tags in the dependency report are kept balanced even if there is a ProjectBuildingException when the details of the dependency are being loaded.

Fixes [MPIR-412](https://issues.apache.org/jira/browse/MPIR-412)