### PR TITLE
update plexus-utils to 4.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -375,7 +375,7 @@ under the License.
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-xml</artifactId>
-      <version>4.0.0</version>
+      <version>3.0.0</version>
     </dependency>
     <dependency>
       <groupId>org.codehaus.plexus</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -370,7 +370,12 @@ under the License.
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-utils</artifactId>
-      <version>3.5.1</version>
+      <version>4.0.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-xml</artifactId>
+      <version>4.0.0</version>
     </dependency>
     <dependency>
       <groupId>org.codehaus.plexus</groupId>


### PR DESCRIPTION
I'm pushing this one up to see what happens and what people think. I'm not confident in it though. The split of plexus-utils and plexus-xml in 4.0.0 risks split package problems in Java 9+:

https://jlbp.dev/JLBP-19