### PR TITLE
The project builder should be given the correct system properties

### DIFF
--- a/src/main/java/org/apache/maven/report/projectinfo/IndexReport.java
+++ b/src/main/java/org/apache/maven/report/projectinfo/IndexReport.java
@@ -28,6 +28,7 @@ import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.ProjectBuilder;
+import org.apache.maven.project.ProjectBuildingRequest;
 import org.codehaus.plexus.i18n.I18N;
 
 /**
@@ -66,6 +67,7 @@ public class IndexReport extends AbstractProjectInfoReport {
                 project,
                 getReactorProjects(),
                 projectBuilder,
+                getSession().getProjectBuildingRequest(),
                 localRepository,
                 getName(locale),
                 getDescription(locale),
@@ -106,6 +108,7 @@ public class IndexReport extends AbstractProjectInfoReport {
                 MavenProject project,
                 List<MavenProject> reactorProjects,
                 ProjectBuilder projectBuilder,
+                ProjectBuildingRequest buildingRequest,
                 ArtifactRepository localRepository,
                 String title,
                 String description,
@@ -114,7 +117,17 @@ public class IndexReport extends AbstractProjectInfoReport {
                 Locale locale,
                 Log log,
                 SiteTool siteTool) {
-            super(sink, project, reactorProjects, projectBuilder, localRepository, i18n, locale, log, siteTool);
+            super(
+                    sink,
+                    project,
+                    reactorProjects,
+                    projectBuilder,
+                    buildingRequest,
+                    localRepository,
+                    i18n,
+                    locale,
+                    log,
+                    siteTool);
 
             this.title = title;
 

--- a/src/main/java/org/apache/maven/report/projectinfo/ModulesReport.java
+++ b/src/main/java/org/apache/maven/report/projectinfo/ModulesReport.java
@@ -67,6 +67,7 @@ public class ModulesReport extends AbstractProjectInfoReport {
                         getProject(),
                         getReactorProjects(),
                         projectBuilder,
+                        getSession().getProjectBuildingRequest(),
                         localRepository,
                         getI18N(locale),
                         locale,
@@ -102,6 +103,8 @@ public class ModulesReport extends AbstractProjectInfoReport {
 
         protected ProjectBuilder projectBuilder;
 
+        protected ProjectBuildingRequest buildingRequest;
+
         protected ArtifactRepository localRepository;
 
         protected SiteTool siteTool;
@@ -111,6 +114,7 @@ public class ModulesReport extends AbstractProjectInfoReport {
                 MavenProject project,
                 List<MavenProject> reactorProjects,
                 ProjectBuilder projectBuilder,
+                ProjectBuildingRequest buildingRequest,
                 ArtifactRepository localRepository,
                 I18N i18n,
                 Locale locale,
@@ -121,6 +125,7 @@ public class ModulesReport extends AbstractProjectInfoReport {
             this.project = project;
             this.reactorProjects = reactorProjects;
             this.projectBuilder = projectBuilder;
+            this.buildingRequest = buildingRequest;
             this.localRepository = localRepository;
             this.siteTool = siteTool;
             this.log = log;
@@ -157,7 +162,7 @@ public class ModulesReport extends AbstractProjectInfoReport {
 
             final String baseUrl = getDistMgmntSiteUrl(project);
 
-            ProjectBuildingRequest buildingRequest = new DefaultProjectBuildingRequest();
+            ProjectBuildingRequest buildingRequest = new DefaultProjectBuildingRequest(this.buildingRequest);
             buildingRequest.setLocalRepository(localRepository);
             buildingRequest.setProcessPlugins(false);
 


### PR DESCRIPTION
The project builder must be given the correct system properties 
in order to be able to properly compute profile activation.
See https://github.com/apache/maven/pull/1603

