### PR TITLE
Use the resolver's own HTTP transport in tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -349,14 +349,8 @@ under the License.
     </dependency>
     <dependency>
       <groupId>org.apache.maven.resolver</groupId>
-      <artifactId>maven-resolver-transport-wagon</artifactId>
+      <artifactId>maven-resolver-transport-http</artifactId>
       <version>${resolverVersion}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.maven.wagon</groupId>
-      <artifactId>wagon-http-lightweight</artifactId>
-      <version>3.5.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
The test classpath carried two artifacts to give Resolver a way of speaking HTTP:

```xml
<artifactId>maven-resolver-transport-wagon</artifactId>
<artifactId>wagon-http-lightweight</artifactId>
```

Resolver has had its own HTTP transport since 1.0, so `maven-resolver-transport-http` at the same `${resolverVersion}` does the same job on its own. `maven-resolver-connector-basic` stays as it is — that is the connector, not the transport.

`wagon-http-lightweight` is additionally marked for removal in Wagon 4.0.0, and nothing here needs a Wagon provider in particular; it was only ever the thing on the other side of the wagon transport.

**Verified:** `mvn test` gives 30 tests, 0 failures both before and after.

This came out of a survey of how Maven projects actually depend on Wagon. The same pattern appears in maven-checkstyle-plugin and maven-surefire-report-plugin, which are getting the same change. It does **not** work in maven-doap-plugin, whose tests resolve through the legacy `maven-compat` `WagonManager` and so genuinely need a Wagon provider registered for `https` — that one is being left alone.
