### PR TITLE
Document which Maven Site Plugin version the reports need

### DIFF
--- a/src/site/markdown/usage.md
+++ b/src/site/markdown/usage.md
@@ -29,3 +29,38 @@ under the License.
 Maven has been configured to create the project info reports by default. There's no need to configure anything in your `pom.xml` to generate the project information reports.
 
 Simply running `mvn site` would generate the project information documentation. For more information on how to customize the Project Information Reports Plugin, check the examples on the [Introduction](./index.html) page.
+
+## Required Maven Site Plugin version
+
+A report plugin does not render with its own Doxia. It renders with the Doxia that the
+[Maven Site Plugin](https://maven.apache.org/plugins/maven-site-plugin/history.html#maven-site-plugin-vs-doxia-vs-doxia-sitetools)
+in use provides, so the version of the Site Plugin decides which Doxia the reports get.
+
+Versions **3.7.0 to 3.9.0** of this plugin are built against Doxia 2 and need
+**Maven Site Plugin 3.21.0 or newer**, which is the first version providing it.
+
+This is easy to run into without changing anything, because Maven 3.9.x still binds Maven Site Plugin
+**3.12.1** by default, and that version provides Doxia 1. The symptom is a warning per affected report
+and a report that stops part way through, while the build still reports success:
+
+```
+[WARNING] An issue has occurred with maven-project-info-reports-plugin:3.9.0:issue-management report,
+skipping LinkageError 'void org.apache.maven.doxia.sink.Sink.verbatim()',
+please report an issue to Maven dev team.
+```
+
+The reports affected are `ci-management`, `dependency-info`, `issue-management`, `licenses` and `scm`.
+
+To avoid it, declare the Site Plugin version explicitly rather than relying on the default:
+
+```xml
+<build>
+  <plugins>
+    <plugin>
+      <groupId>org.apache.maven.plugins</groupId>
+      <artifactId>maven-site-plugin</artifactId>
+      <version>3.22.0</version>
+    </plugin>
+  </plugins>
+</build>
+```


### PR DESCRIPTION
Addresses the documentation half of #103, the first of the two options @hboutemy laid out there.

The code half is done: apache/maven-reporting-impl#243 is merged, so `AbstractMavenReportRenderer` no longer calls the Doxia 2 only `Sink.verbatim()`. But that only helps once maven-reporting-impl is released and this plugin picks it up. Every released version from 3.7.0 to 3.9.0 stays affected, and right now nothing tells a user why five of their reports are truncated.

It is easy to hit without configuring anything: **Maven 3.9.x still binds Maven Site Plugin 3.12.1 by default**, which provides Doxia 1, and a report plugin renders with the Doxia the Site Plugin provides rather than its own. `DefaultMavenReportExecutor` imports the `org.apache.maven.doxia.sink` package from the Site Plugin's class realm and excludes `doxia-sink-api` from the report plugin's own dependencies, so the plugin's declared Doxia version is not what it gets. I reproduced this on Maven 3.9.16 with MPIR 3.9.0.

The failure is quiet in the worst way: a `[WARNING]` per report, the report cut off part way through, and `BUILD SUCCESS`.

So this adds a section to the usage page stating the requirement, naming the affected reports, quoting the warning so it is searchable, and showing how to pin the Site Plugin.

The requirement is scoped to 3.7.0 through 3.9.0 rather than written as open ended, since the reporting-impl fix is meant to make later versions work with either Doxia and the wording should not outlive that.

Rendered with `mvn site` to check the formatting.