### PR TITLE
Remove maven-compat

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -295,12 +295,6 @@ under the License.
 
     <!-- Test -->
     <dependency>
-      <groupId>org.apache.maven</groupId>
-      <artifactId>maven-compat</artifactId>
-      <version>${mavenVersion}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.httpunit</groupId>
       <artifactId>httpunit</artifactId>
       <version>1.7.3</version>

--- a/src/main/java/org/apache/maven/report/projectinfo/AbstractProjectInfoReport.java
+++ b/src/main/java/org/apache/maven/report/projectinfo/AbstractProjectInfoReport.java
@@ -40,7 +40,6 @@ import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.ProjectBuilder;
 import org.apache.maven.reporting.AbstractMavenReport;
 import org.apache.maven.reporting.MavenReportException;
-import org.apache.maven.repository.RepositorySystem;
 import org.apache.maven.settings.Settings;
 import org.codehaus.plexus.i18n.I18N;
 import org.codehaus.plexus.interpolation.EnvarBasedValueSource;
@@ -121,19 +120,13 @@ public abstract class AbstractProjectInfoReport extends AbstractMavenReport {
     // ----------------------------------------------------------------------
 
     /**
-     * Artifact Factory component.
-     */
-    final RepositorySystem repositorySystem;
-
-    /**
      * Internationalization component, could support also custom bundle using {@link #customBundle}.
      */
     private I18N i18n;
 
     protected final ProjectBuilder projectBuilder;
 
-    protected AbstractProjectInfoReport(RepositorySystem repositorySystem, I18N i18n, ProjectBuilder projectBuilder) {
-        this.repositorySystem = repositorySystem;
+    protected AbstractProjectInfoReport(I18N i18n, ProjectBuilder projectBuilder) {
         this.i18n = i18n;
         this.projectBuilder = projectBuilder;
     }

--- a/src/main/java/org/apache/maven/report/projectinfo/CiManagementReport.java
+++ b/src/main/java/org/apache/maven/report/projectinfo/CiManagementReport.java
@@ -33,7 +33,6 @@ import org.apache.maven.model.Notifier;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.project.ProjectBuilder;
 import org.apache.maven.reporting.MavenReportException;
-import org.apache.maven.repository.RepositorySystem;
 import org.codehaus.plexus.i18n.I18N;
 
 /**
@@ -46,8 +45,8 @@ import org.codehaus.plexus.i18n.I18N;
 public class CiManagementReport extends AbstractProjectInfoReport {
 
     @Inject
-    public CiManagementReport(RepositorySystem repositorySystem, I18N i18n, ProjectBuilder projectBuilder) {
-        super(repositorySystem, i18n, projectBuilder);
+    public CiManagementReport(I18N i18n, ProjectBuilder projectBuilder) {
+        super(i18n, projectBuilder);
     }
     // ----------------------------------------------------------------------
     // Public methods

--- a/src/main/java/org/apache/maven/report/projectinfo/DependenciesReport.java
+++ b/src/main/java/org/apache/maven/report/projectinfo/DependenciesReport.java
@@ -46,7 +46,6 @@ import org.apache.maven.report.projectinfo.dependencies.DependenciesReportConfig
 import org.apache.maven.report.projectinfo.dependencies.RepositoryUtils;
 import org.apache.maven.report.projectinfo.dependencies.renderer.DependenciesRenderer;
 import org.apache.maven.reporting.MavenReportException;
-import org.apache.maven.repository.RepositorySystem;
 import org.apache.maven.shared.dependency.graph.DependencyGraphBuilder;
 import org.apache.maven.shared.dependency.graph.DependencyGraphBuilderException;
 import org.apache.maven.shared.dependency.graph.DependencyNode;
@@ -103,13 +102,12 @@ public class DependenciesReport extends AbstractProjectInfoReport {
 
     @Inject
     protected DependenciesReport(
-            RepositorySystem repositorySystem,
             I18N i18n,
             ProjectBuilder projectBuilder,
             @Named("default") DependencyGraphBuilder dependencyGraphBuilder,
             JarClassesAnalysis classesAnalyzer,
             RepositoryUtils repoUtils) {
-        super(repositorySystem, i18n, projectBuilder);
+        super(i18n, projectBuilder);
         this.dependencyGraphBuilder = dependencyGraphBuilder;
         this.classesAnalyzer = classesAnalyzer;
         this.repoUtils = repoUtils;

--- a/src/main/java/org/apache/maven/report/projectinfo/DependencyConvergenceReport.java
+++ b/src/main/java/org/apache/maven/report/projectinfo/DependencyConvergenceReport.java
@@ -47,7 +47,6 @@ import org.apache.maven.project.ProjectBuildingRequest;
 import org.apache.maven.report.projectinfo.dependencies.DependencyVersionMap;
 import org.apache.maven.report.projectinfo.dependencies.SinkSerializingDependencyNodeVisitor;
 import org.apache.maven.reporting.MavenReportException;
-import org.apache.maven.repository.RepositorySystem;
 import org.apache.maven.shared.artifact.filter.StrictPatternIncludesArtifactFilter;
 import org.apache.maven.shared.dependency.graph.DependencyCollectorBuilder;
 import org.apache.maven.shared.dependency.graph.DependencyCollectorBuilderException;
@@ -99,11 +98,8 @@ public class DependencyConvergenceReport extends AbstractProjectInfoReport {
 
     @Inject
     protected DependencyConvergenceReport(
-            RepositorySystem repositorySystem,
-            I18N i18n,
-            ProjectBuilder projectBuilder,
-            DependencyCollectorBuilder dependencyCollectorBuilder) {
-        super(repositorySystem, i18n, projectBuilder);
+            I18N i18n, ProjectBuilder projectBuilder, DependencyCollectorBuilder dependencyCollectorBuilder) {
+        super(i18n, projectBuilder);
         this.dependencyCollectorBuilder = dependencyCollectorBuilder;
     }
 

--- a/src/main/java/org/apache/maven/report/projectinfo/DependencyInformationReport.java
+++ b/src/main/java/org/apache/maven/report/projectinfo/DependencyInformationReport.java
@@ -28,7 +28,6 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.ProjectBuilder;
 import org.apache.maven.reporting.MavenReportException;
-import org.apache.maven.repository.RepositorySystem;
 import org.codehaus.plexus.i18n.I18N;
 
 /**
@@ -56,8 +55,8 @@ public final class DependencyInformationReport extends AbstractProjectInfoReport
     protected String packaging;
 
     @Inject
-    public DependencyInformationReport(RepositorySystem repositorySystem, I18N i18n, ProjectBuilder projectBuilder) {
-        super(repositorySystem, i18n, projectBuilder);
+    public DependencyInformationReport(I18N i18n, ProjectBuilder projectBuilder) {
+        super(i18n, projectBuilder);
     }
 
     // ----------------------------------------------------------------------

--- a/src/main/java/org/apache/maven/report/projectinfo/DependencyManagementReport.java
+++ b/src/main/java/org/apache/maven/report/projectinfo/DependencyManagementReport.java
@@ -22,7 +22,6 @@ import javax.inject.Inject;
 
 import java.util.Locale;
 
-import org.apache.maven.artifact.metadata.ArtifactMetadataSource;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.project.DefaultProjectBuildingRequest;
@@ -32,7 +31,6 @@ import org.apache.maven.report.projectinfo.dependencies.ManagementDependencies;
 import org.apache.maven.report.projectinfo.dependencies.RepositoryUtils;
 import org.apache.maven.report.projectinfo.dependencies.renderer.DependencyManagementRenderer;
 import org.apache.maven.reporting.MavenReportException;
-import org.apache.maven.repository.RepositorySystem;
 import org.codehaus.plexus.i18n.I18N;
 
 /**
@@ -57,24 +55,11 @@ public class DependencyManagementReport extends AbstractProjectInfoReport {
     // Mojo components
     // ----------------------------------------------------------------------
 
-    /**
-     * Artifact metadata source component.
-     *
-     * @since 2.4
-     */
-    protected final ArtifactMetadataSource artifactMetadataSource;
-
     private final RepositoryUtils repoUtils;
 
     @Inject
-    protected DependencyManagementReport(
-            RepositorySystem repositorySystem,
-            I18N i18n,
-            ProjectBuilder projectBuilder,
-            ArtifactMetadataSource artifactMetadataSource,
-            RepositoryUtils repoUtils) {
-        super(repositorySystem, i18n, projectBuilder);
-        this.artifactMetadataSource = artifactMetadataSource;
+    protected DependencyManagementReport(I18N i18n, ProjectBuilder projectBuilder, RepositoryUtils repoUtils) {
+        super(i18n, projectBuilder);
         this.repoUtils = repoUtils;
     }
 
@@ -107,8 +92,6 @@ public class DependencyManagementReport extends AbstractProjectInfoReport {
                 getI18N(locale),
                 getLog(),
                 getManagementDependencies(),
-                artifactMetadataSource,
-                repositorySystem,
                 buildingRequest,
                 repoUtils,
                 getLicenseMappings());

--- a/src/main/java/org/apache/maven/report/projectinfo/DistributionManagementReport.java
+++ b/src/main/java/org/apache/maven/report/projectinfo/DistributionManagementReport.java
@@ -28,7 +28,6 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.ProjectBuilder;
 import org.apache.maven.reporting.MavenReportException;
-import org.apache.maven.repository.RepositorySystem;
 import org.codehaus.plexus.i18n.I18N;
 import org.codehaus.plexus.util.StringUtils;
 
@@ -42,8 +41,8 @@ import org.codehaus.plexus.util.StringUtils;
 public class DistributionManagementReport extends AbstractProjectInfoReport {
 
     @Inject
-    public DistributionManagementReport(RepositorySystem repositorySystem, I18N i18n, ProjectBuilder projectBuilder) {
-        super(repositorySystem, i18n, projectBuilder);
+    public DistributionManagementReport(I18N i18n, ProjectBuilder projectBuilder) {
+        super(i18n, projectBuilder);
     }
     // ----------------------------------------------------------------------
     // Public methods

--- a/src/main/java/org/apache/maven/report/projectinfo/IndexReport.java
+++ b/src/main/java/org/apache/maven/report/projectinfo/IndexReport.java
@@ -31,7 +31,6 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.ProjectBuilder;
 import org.apache.maven.project.ProjectBuildingRequest;
-import org.apache.maven.repository.RepositorySystem;
 import org.codehaus.plexus.i18n.I18N;
 
 /**
@@ -45,8 +44,8 @@ import org.codehaus.plexus.i18n.I18N;
 public class IndexReport extends AbstractProjectInfoReport {
 
     @Inject
-    public IndexReport(RepositorySystem repositorySystem, I18N i18n, ProjectBuilder projectBuilder) {
-        super(repositorySystem, i18n, projectBuilder);
+    public IndexReport(I18N i18n, ProjectBuilder projectBuilder) {
+        super(i18n, projectBuilder);
     }
     // ----------------------------------------------------------------------
     // Public methods

--- a/src/main/java/org/apache/maven/report/projectinfo/IssueManagementReport.java
+++ b/src/main/java/org/apache/maven/report/projectinfo/IssueManagementReport.java
@@ -28,7 +28,6 @@ import org.apache.maven.model.Model;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.project.ProjectBuilder;
 import org.apache.maven.reporting.MavenReportException;
-import org.apache.maven.repository.RepositorySystem;
 import org.codehaus.plexus.i18n.I18N;
 
 /**
@@ -41,8 +40,8 @@ import org.codehaus.plexus.i18n.I18N;
 public class IssueManagementReport extends AbstractProjectInfoReport {
 
     @Inject
-    public IssueManagementReport(RepositorySystem repositorySystem, I18N i18n, ProjectBuilder projectBuilder) {
-        super(repositorySystem, i18n, projectBuilder);
+    public IssueManagementReport(I18N i18n, ProjectBuilder projectBuilder) {
+        super(i18n, projectBuilder);
     }
     // ----------------------------------------------------------------------
     // Public methods

--- a/src/main/java/org/apache/maven/report/projectinfo/LicensesReport.java
+++ b/src/main/java/org/apache/maven/report/projectinfo/LicensesReport.java
@@ -39,7 +39,6 @@ import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.ProjectBuilder;
 import org.apache.maven.reporting.MavenReportException;
-import org.apache.maven.repository.RepositorySystem;
 import org.apache.maven.settings.Settings;
 import org.codehaus.plexus.i18n.I18N;
 
@@ -80,8 +79,8 @@ public class LicensesReport extends AbstractProjectInfoReport {
     private String licenseFileEncoding;
 
     @Inject
-    public LicensesReport(RepositorySystem repositorySystem, I18N i18n, ProjectBuilder projectBuilder) {
-        super(repositorySystem, i18n, projectBuilder);
+    public LicensesReport(I18N i18n, ProjectBuilder projectBuilder) {
+        super(i18n, projectBuilder);
     }
 
     // ----------------------------------------------------------------------

--- a/src/main/java/org/apache/maven/report/projectinfo/MailingListsReport.java
+++ b/src/main/java/org/apache/maven/report/projectinfo/MailingListsReport.java
@@ -33,7 +33,6 @@ import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.project.ProjectBuilder;
 import org.apache.maven.reporting.MavenReportException;
-import org.apache.maven.repository.RepositorySystem;
 import org.codehaus.plexus.i18n.I18N;
 import org.codehaus.plexus.util.StringUtils;
 
@@ -48,8 +47,8 @@ import org.codehaus.plexus.util.StringUtils;
 public class MailingListsReport extends AbstractProjectInfoReport {
 
     @Inject
-    public MailingListsReport(RepositorySystem repositorySystem, I18N i18n, ProjectBuilder projectBuilder) {
-        super(repositorySystem, i18n, projectBuilder);
+    public MailingListsReport(I18N i18n, ProjectBuilder projectBuilder) {
+        super(i18n, projectBuilder);
     }
     // ----------------------------------------------------------------------
     // Public methods

--- a/src/main/java/org/apache/maven/report/projectinfo/ModulesReport.java
+++ b/src/main/java/org/apache/maven/report/projectinfo/ModulesReport.java
@@ -39,7 +39,6 @@ import org.apache.maven.project.ProjectBuilder;
 import org.apache.maven.project.ProjectBuildingException;
 import org.apache.maven.project.ProjectBuildingRequest;
 import org.apache.maven.reporting.MavenReportException;
-import org.apache.maven.repository.RepositorySystem;
 import org.codehaus.plexus.i18n.I18N;
 
 /**
@@ -52,8 +51,8 @@ import org.codehaus.plexus.i18n.I18N;
 public class ModulesReport extends AbstractProjectInfoReport {
 
     @Inject
-    public ModulesReport(RepositorySystem repositorySystem, I18N i18n, ProjectBuilder projectBuilder) {
-        super(repositorySystem, i18n, projectBuilder);
+    public ModulesReport(I18N i18n, ProjectBuilder projectBuilder) {
+        super(i18n, projectBuilder);
     }
 
     // ----------------------------------------------------------------------

--- a/src/main/java/org/apache/maven/report/projectinfo/PluginManagementReport.java
+++ b/src/main/java/org/apache/maven/report/projectinfo/PluginManagementReport.java
@@ -39,8 +39,8 @@ import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.ProjectBuilder;
 import org.apache.maven.project.ProjectBuildingException;
 import org.apache.maven.project.ProjectBuildingRequest;
+import org.apache.maven.report.projectinfo.dependencies.RepositoryUtils;
 import org.apache.maven.reporting.MavenReportException;
-import org.apache.maven.repository.RepositorySystem;
 import org.apache.maven.shared.artifact.filter.PatternExcludesArtifactFilter;
 import org.codehaus.plexus.i18n.I18N;
 import org.codehaus.plexus.util.StringUtils;
@@ -64,9 +64,12 @@ public class PluginManagementReport extends AbstractProjectInfoReport {
     @Parameter
     private List<String> pluginManagementExcludes = null;
 
+    private final RepositoryUtils repoUtils;
+
     @Inject
-    public PluginManagementReport(RepositorySystem repositorySystem, I18N i18n, ProjectBuilder projectBuilder) {
-        super(repositorySystem, i18n, projectBuilder);
+    public PluginManagementReport(I18N i18n, ProjectBuilder projectBuilder, RepositoryUtils repoUtils) {
+        super(i18n, projectBuilder);
+        this.repoUtils = repoUtils;
     }
 
     // ----------------------------------------------------------------------
@@ -83,7 +86,7 @@ public class PluginManagementReport extends AbstractProjectInfoReport {
                 project.getPluginManagement().getPlugins(),
                 project,
                 projectBuilder,
-                repositorySystem,
+                repoUtils,
                 getSession().getProjectBuildingRequest(),
                 pluginManagementExcludes);
         r.render();
@@ -129,7 +132,7 @@ public class PluginManagementReport extends AbstractProjectInfoReport {
 
         private final ProjectBuilder projectBuilder;
 
-        private final RepositorySystem repositorySystem;
+        private final RepositoryUtils repoUtils;
 
         private final ProjectBuildingRequest buildingRequest;
 
@@ -143,7 +146,7 @@ public class PluginManagementReport extends AbstractProjectInfoReport {
          * @param plugins {@link Plugin}
          * @param project {@link MavenProject}
          * @param projectBuilder {@link ProjectBuilder}
-         * @param repositorySystem {@link RepositorySystem}
+         * @param repoUtils {@link RepositoryUtils}
          * @param buildingRequest {@link ProjectBuildingRequest}
          * @param excludes the list of plugins to be excluded from the report
          */
@@ -155,7 +158,7 @@ public class PluginManagementReport extends AbstractProjectInfoReport {
                 List<Plugin> plugins,
                 MavenProject project,
                 ProjectBuilder projectBuilder,
-                RepositorySystem repositorySystem,
+                RepositoryUtils repoUtils,
                 ProjectBuildingRequest buildingRequest,
                 List<String> excludes) {
             super(sink, i18n, locale);
@@ -168,7 +171,7 @@ public class PluginManagementReport extends AbstractProjectInfoReport {
 
             this.projectBuilder = projectBuilder;
 
-            this.repositorySystem = repositorySystem;
+            this.repoUtils = repoUtils;
 
             this.buildingRequest = buildingRequest;
 
@@ -223,7 +226,7 @@ public class PluginManagementReport extends AbstractProjectInfoReport {
                     versionRange = VersionRange.createFromVersion(plugin.getVersion());
                 }
 
-                Artifact pluginArtifact = repositorySystem.createProjectArtifact(
+                Artifact pluginArtifact = repoUtils.createProjectArtifact(
                         plugin.getGroupId(), plugin.getArtifactId(), versionRange.toString());
 
                 if (patternExcludesArtifactFilter.include(pluginArtifact)) {

--- a/src/main/java/org/apache/maven/report/projectinfo/PluginsReport.java
+++ b/src/main/java/org/apache/maven/report/projectinfo/PluginsReport.java
@@ -40,8 +40,8 @@ import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.ProjectBuilder;
 import org.apache.maven.project.ProjectBuildingException;
 import org.apache.maven.project.ProjectBuildingRequest;
+import org.apache.maven.report.projectinfo.dependencies.RepositoryUtils;
 import org.apache.maven.reporting.MavenReportException;
-import org.apache.maven.repository.RepositorySystem;
 import org.codehaus.plexus.i18n.I18N;
 import org.codehaus.plexus.util.StringUtils;
 
@@ -54,9 +54,12 @@ import org.codehaus.plexus.util.StringUtils;
 @Mojo(name = "plugins", requiresDependencyResolution = ResolutionScope.TEST)
 public class PluginsReport extends AbstractProjectInfoReport {
 
+    private final RepositoryUtils repoUtils;
+
     @Inject
-    public PluginsReport(RepositorySystem repositorySystem, I18N i18n, ProjectBuilder projectBuilder) {
-        super(repositorySystem, i18n, projectBuilder);
+    public PluginsReport(I18N i18n, ProjectBuilder projectBuilder, RepositoryUtils repoUtils) {
+        super(i18n, projectBuilder);
+        this.repoUtils = repoUtils;
     }
     // ----------------------------------------------------------------------
     // Public methods
@@ -84,7 +87,7 @@ public class PluginsReport extends AbstractProjectInfoReport {
                 project.getReportPlugins(),
                 project,
                 projectBuilder,
-                repositorySystem,
+                repoUtils,
                 getSession().getProjectBuildingRequest());
         r.render();
     }
@@ -117,7 +120,7 @@ public class PluginsReport extends AbstractProjectInfoReport {
 
         private final ProjectBuilder projectBuilder;
 
-        private final RepositorySystem repositorySystem;
+        private final RepositoryUtils repoUtils;
 
         private final ProjectBuildingRequest buildingRequest;
 
@@ -130,7 +133,7 @@ public class PluginsReport extends AbstractProjectInfoReport {
          * @param reports {@link Artifact}
          * @param project {@link MavenProject}
          * @param projectBuilder {@link ProjectBuilder}
-         * @param repositorySystem {@link RepositorySystem}
+         * @param repoUtils {@link RepositoryUtils}
          * @param buildingRequest {@link ProjectBuildingRequest}
          *
          */
@@ -143,7 +146,7 @@ public class PluginsReport extends AbstractProjectInfoReport {
                 List<ReportPlugin> reports,
                 MavenProject project,
                 ProjectBuilder projectBuilder,
-                RepositorySystem repositorySystem,
+                RepositoryUtils repoUtils,
                 ProjectBuildingRequest buildingRequest) {
             super(sink, i18n, locale);
 
@@ -157,7 +160,7 @@ public class PluginsReport extends AbstractProjectInfoReport {
 
             this.projectBuilder = projectBuilder;
 
-            this.repositorySystem = repositorySystem;
+            this.repoUtils = repoUtils;
 
             this.buildingRequest = buildingRequest;
         }
@@ -206,7 +209,7 @@ public class PluginsReport extends AbstractProjectInfoReport {
             for (GAV plugin : list) {
                 VersionRange versionRange = VersionRange.createFromVersion(plugin.getVersion());
 
-                Artifact pluginArtifact = repositorySystem.createProjectArtifact(
+                Artifact pluginArtifact = repoUtils.createProjectArtifact(
                         plugin.getGroupId(), plugin.getArtifactId(), versionRange.toString());
                 try {
                     MavenProject pluginProject =

--- a/src/main/java/org/apache/maven/report/projectinfo/ScmReport.java
+++ b/src/main/java/org/apache/maven/report/projectinfo/ScmReport.java
@@ -32,7 +32,6 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.ProjectBuilder;
 import org.apache.maven.reporting.MavenReportException;
-import org.apache.maven.repository.RepositorySystem;
 import org.apache.maven.scm.manager.ScmManager;
 import org.apache.maven.scm.provider.git.repository.GitScmProviderRepository;
 import org.apache.maven.scm.provider.hg.repository.HgScmProviderRepository;
@@ -99,9 +98,8 @@ public class ScmReport extends AbstractProjectInfoReport {
     protected final ScmManager scmManager;
 
     @Inject
-    public ScmReport(
-            RepositorySystem repositorySystem, I18N i18n, ProjectBuilder projectBuilder, ScmManager scmManager) {
-        super(repositorySystem, i18n, projectBuilder);
+    public ScmReport(I18N i18n, ProjectBuilder projectBuilder, ScmManager scmManager) {
+        super(i18n, projectBuilder);
         this.scmManager = scmManager;
     }
 

--- a/src/main/java/org/apache/maven/report/projectinfo/SummaryReport.java
+++ b/src/main/java/org/apache/maven/report/projectinfo/SummaryReport.java
@@ -33,7 +33,6 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.ProjectBuilder;
 import org.apache.maven.reporting.MavenReportException;
-import org.apache.maven.repository.RepositorySystem;
 import org.codehaus.plexus.i18n.I18N;
 import org.codehaus.plexus.util.FileUtils;
 import org.codehaus.plexus.util.StringUtils;
@@ -49,8 +48,8 @@ import org.codehaus.plexus.util.xml.Xpp3Dom;
 public class SummaryReport extends AbstractProjectInfoReport {
 
     @Inject
-    public SummaryReport(RepositorySystem repositorySystem, I18N i18n, ProjectBuilder projectBuilder) {
-        super(repositorySystem, i18n, projectBuilder);
+    public SummaryReport(I18N i18n, ProjectBuilder projectBuilder) {
+        super(i18n, projectBuilder);
     }
 
     // ----------------------------------------------------------------------

--- a/src/main/java/org/apache/maven/report/projectinfo/TeamReport.java
+++ b/src/main/java/org/apache/maven/report/projectinfo/TeamReport.java
@@ -38,7 +38,6 @@ import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.ProjectBuilder;
 import org.apache.maven.report.projectinfo.avatars.AvatarsProvider;
 import org.apache.maven.reporting.MavenReportException;
-import org.apache.maven.repository.RepositorySystem;
 import org.codehaus.plexus.i18n.I18N;
 import org.codehaus.plexus.util.StringUtils;
 
@@ -91,12 +90,8 @@ public class TeamReport extends AbstractProjectInfoReport {
     private final Map<String, AvatarsProvider> avatarsProviders;
 
     @Inject
-    public TeamReport(
-            RepositorySystem repositorySystem,
-            I18N i18n,
-            ProjectBuilder projectBuilder,
-            Map<String, AvatarsProvider> avatarsProviders) {
-        super(repositorySystem, i18n, projectBuilder);
+    public TeamReport(I18N i18n, ProjectBuilder projectBuilder, Map<String, AvatarsProvider> avatarsProviders) {
+        super(i18n, projectBuilder);
         this.avatarsProviders = avatarsProviders;
     }
 

--- a/src/main/java/org/apache/maven/report/projectinfo/dependencies/RepositoryUtils.java
+++ b/src/main/java/org/apache/maven/report/projectinfo/dependencies/RepositoryUtils.java
@@ -23,7 +23,16 @@ import javax.inject.Named;
 import javax.inject.Provider;
 import javax.inject.Singleton;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.DefaultArtifact;
+import org.apache.maven.artifact.handler.manager.ArtifactHandlerManager;
+import org.apache.maven.artifact.repository.ArtifactRepository;
+import org.apache.maven.artifact.versioning.ArtifactVersion;
+import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
+import org.apache.maven.artifact.versioning.VersionRange;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.project.DefaultProjectBuildingRequest;
 import org.apache.maven.project.MavenProject;
@@ -34,6 +43,10 @@ import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.resolution.ArtifactRequest;
 import org.eclipse.aether.resolution.ArtifactResolutionException;
 import org.eclipse.aether.resolution.ArtifactResult;
+import org.eclipse.aether.resolution.VersionRangeRequest;
+import org.eclipse.aether.resolution.VersionRangeResolutionException;
+import org.eclipse.aether.resolution.VersionRangeResult;
+import org.eclipse.aether.version.Version;
 
 /**
  * Utility methods to play with repository.
@@ -47,19 +60,61 @@ public class RepositoryUtils {
 
     private final ProjectBuilder projectBuilder;
 
+    private final ArtifactHandlerManager artifactHandlerManager;
+
     private final RepositorySystem repositorySystem;
 
     private final Provider<MavenSession> sessionProvider;
 
     /**
      * @param projectBuilder {@link ProjectBuilder}
+     * @param artifactHandlerManager {@link ArtifactHandlerManager}
+     * @param repositorySystem {@link RepositorySystem}
+     * @param sessionProvider the current {@link MavenSession}
      */
     @Inject
     public RepositoryUtils(
-            ProjectBuilder projectBuilder, RepositorySystem repositorySystem, Provider<MavenSession> sessionProvider) {
+            ProjectBuilder projectBuilder,
+            ArtifactHandlerManager artifactHandlerManager,
+            RepositorySystem repositorySystem,
+            Provider<MavenSession> sessionProvider) {
         this.projectBuilder = projectBuilder;
+        this.artifactHandlerManager = artifactHandlerManager;
         this.repositorySystem = repositorySystem;
         this.sessionProvider = sessionProvider;
+    }
+
+    /**
+     * Create an artifact of type <code>pom</code> for the given coordinates.
+     *
+     * @param groupId the group id
+     * @param artifactId the artifact id
+     * @param version the version, may be a version range
+     * @return the artifact, never {@code null}
+     */
+    public Artifact createProjectArtifact(String groupId, String artifactId, String version) {
+        return createArtifact(groupId, artifactId, version, null, "pom");
+    }
+
+    /**
+     * Create an artifact for the given coordinates.
+     *
+     * @param groupId the group id
+     * @param artifactId the artifact id
+     * @param version the version, may be a version range
+     * @param scope the dependency scope, may be {@code null}
+     * @param type the artifact type
+     * @return the artifact, never {@code null}
+     */
+    public Artifact createArtifact(String groupId, String artifactId, String version, String scope, String type) {
+        return new DefaultArtifact(
+                groupId,
+                artifactId,
+                VersionRange.createFromVersion(version),
+                scope,
+                type,
+                null,
+                artifactHandlerManager.getArtifactHandler(type));
     }
 
     /**
@@ -77,6 +132,33 @@ public class RepositoryUtils {
 
         artifact.setFile(result.getArtifact().getFile());
         artifact.setResolved(true);
+    }
+
+    /**
+     * Retrieve the versions available in the given remote repositories for the artifact, whose version may be a
+     * version range. Only the versions matching that range are returned, sorted in ascending order.
+     *
+     * @param artifact the artifact, its version may be a version range
+     * @param remoteRepositories the remote repositories to look the versions up in
+     * @return the matching versions, possibly empty, never {@code null}
+     * @throws VersionRangeResolutionException if the version range could not be resolved at all
+     */
+    public List<ArtifactVersion> getAvailableVersions(Artifact artifact, List<ArtifactRepository> remoteRepositories)
+            throws VersionRangeResolutionException {
+
+        MavenSession session = sessionProvider.get();
+
+        VersionRangeRequest request = new VersionRangeRequest(
+                org.apache.maven.RepositoryUtils.toArtifact(artifact),
+                org.apache.maven.RepositoryUtils.toRepos(remoteRepositories),
+                null);
+        VersionRangeResult result = repositorySystem.resolveVersionRange(session.getRepositorySession(), request);
+
+        List<ArtifactVersion> versions = new ArrayList<>(result.getVersions().size());
+        for (Version version : result.getVersions()) {
+            versions.add(new DefaultArtifactVersion(version.toString()));
+        }
+        return versions;
     }
 
     /**

--- a/src/main/java/org/apache/maven/report/projectinfo/dependencies/renderer/DependencyManagementRenderer.java
+++ b/src/main/java/org/apache/maven/report/projectinfo/dependencies/renderer/DependencyManagementRenderer.java
@@ -20,14 +20,11 @@ package org.apache.maven.report.projectinfo.dependencies.renderer;
 
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
 import org.apache.maven.artifact.Artifact;
-import org.apache.maven.artifact.metadata.ArtifactMetadataRetrievalException;
-import org.apache.maven.artifact.metadata.ArtifactMetadataSource;
 import org.apache.maven.artifact.versioning.ArtifactVersion;
 import org.apache.maven.artifact.versioning.InvalidVersionSpecificationException;
 import org.apache.maven.artifact.versioning.VersionRange;
@@ -43,9 +40,9 @@ import org.apache.maven.report.projectinfo.LicenseMapping;
 import org.apache.maven.report.projectinfo.ProjectInfoReportUtils;
 import org.apache.maven.report.projectinfo.dependencies.ManagementDependencies;
 import org.apache.maven.report.projectinfo.dependencies.RepositoryUtils;
-import org.apache.maven.repository.RepositorySystem;
 import org.codehaus.plexus.i18n.I18N;
 import org.codehaus.plexus.util.StringUtils;
+import org.eclipse.aether.resolution.VersionRangeResolutionException;
 
 /**
  * @author Nick Stolwijk
@@ -55,10 +52,6 @@ public class DependencyManagementRenderer extends AbstractProjectInfoRenderer {
     private final ManagementDependencies dependencies;
 
     private final Log log;
-
-    private final ArtifactMetadataSource artifactMetadataSource;
-
-    private final RepositorySystem repositorySystem;
 
     private final ProjectBuildingRequest buildingRequest;
 
@@ -74,8 +67,6 @@ public class DependencyManagementRenderer extends AbstractProjectInfoRenderer {
      * @param i18n {@link I18N}
      * @param log {@link Log}
      * @param dependencies {@link ManagementDependencies}
-     * @param artifactMetadataSource {@link ArtifactMetadataSource}
-     * @param repositorySystem {@link RepositorySystem}
      * @param buildingRequest {@link ProjectBuildingRequest}
      * @param repoUtils {@link RepositoryUtils}
      * @param licenseMappings {@link LicenseMapping}
@@ -86,8 +77,6 @@ public class DependencyManagementRenderer extends AbstractProjectInfoRenderer {
             I18N i18n,
             Log log,
             ManagementDependencies dependencies,
-            ArtifactMetadataSource artifactMetadataSource,
-            RepositorySystem repositorySystem,
             ProjectBuildingRequest buildingRequest,
             RepositoryUtils repoUtils,
             Map<String, String> licenseMappings) {
@@ -95,8 +84,6 @@ public class DependencyManagementRenderer extends AbstractProjectInfoRenderer {
 
         this.log = log;
         this.dependencies = dependencies;
-        this.artifactMetadataSource = artifactMetadataSource;
-        this.repositorySystem = repositorySystem;
         this.buildingRequest = buildingRequest;
         this.repoUtils = repoUtils;
         this.licenseMappings = licenseMappings;
@@ -197,10 +184,9 @@ public class DependencyManagementRenderer extends AbstractProjectInfoRenderer {
         }
     }
 
-    @SuppressWarnings("unchecked")
     private String[] getDependencyRow(Dependency dependency, boolean hasClassifier) {
 
-        Artifact artifact = repositorySystem.createArtifact(
+        Artifact artifact = repoUtils.createArtifact(
                 dependency.getGroupId(),
                 dependency.getArtifactId(),
                 dependency.getVersion(),
@@ -216,15 +202,8 @@ public class DependencyManagementRenderer extends AbstractProjectInfoRenderer {
                 // MPIR-216: no direct version but version range: need to choose one precise version
                 log.debug("Resolving range for DependencyManagement on " + artifact.getId());
 
-                List<ArtifactVersion> versions = artifactMetadataSource.retrieveAvailableVersions(
-                        artifact, buildingRequest.getLocalRepository(), buildingRequest.getRemoteRepositories());
-
-                // only use versions from range
-                for (Iterator<ArtifactVersion> iter = versions.iterator(); iter.hasNext(); ) {
-                    if (!range.containsVersion(iter.next())) {
-                        iter.remove();
-                    }
-                }
+                List<ArtifactVersion> versions =
+                        repoUtils.getAvailableVersions(artifact, buildingRequest.getRemoteRepositories());
 
                 // select latest, assuming pom information will be the most accurate
                 if (!versions.isEmpty()) {
@@ -252,7 +231,7 @@ public class DependencyManagementRenderer extends AbstractProjectInfoRenderer {
             }
         } catch (InvalidVersionSpecificationException e) {
             log.warn("Unable to parse version for " + artifact.getId(), e);
-        } catch (ArtifactMetadataRetrievalException e) {
+        } catch (VersionRangeResolutionException e) {
             log.warn("Unable to retrieve versions for " + artifact.getId() + " from repository.", e);
         } catch (ProjectBuildingException e) {
             if (log.isDebugEnabled()) {


### PR DESCRIPTION
Removes `maven-compat`. No baseline change — PIR is already on maven 3.9.16 / resolver 1.9.27, and every API used here is present as far back as maven-core 3.6.3, so `<prerequisites>` is untouched.

### The constructor parameter is removed, not retyped

The legacy `org.apache.maven.repository.RepositorySystem` was a constructor parameter of `AbstractProjectInfoReport` and therefore of all 17 report Mojos — but the field was used in **none** of them. Only three call sites needed it, so rather than change the type in 17 places the parameter is deleted and those three go through PIR's own `RepositoryUtils`, which was already an injectable `@Named @Singleton` holding the resolver `RepositorySystem`.

This is a source- and binary-incompatible change to a `protected` constructor. That is unavoidable either way: the parameter's type is the thing being removed, so anyone subclassing `AbstractProjectInfoReport` has to move regardless.

### Not via `MavenRepositorySystem` — that does not work in a plugin

The obvious replacement for the legacy `RepositorySystem` is `org.apache.maven.bridge.MavenRepositorySystem`. **It cannot be used from a plugin.** maven-core does not export `org.apache.maven.bridge` to plugin class realms — it appears in no `<exportedPackages>` entry of `META-INF/maven/extension.xml` in 3.9.16 or 4.0.0-rc-5, while `org.apache.maven.artifact` does.

That swap was tried first. It compiled, all 30 unit tests passed, and it failed only in an integration test:

```
A required class was missing while executing maven-site-plugin:3.22.0:site:
org/apache/maven/bridge/MavenRepositorySystem
```

The plugin-testing harness puts everything on one flat classpath, so realm isolation does not exist there and `mvn verify` stays green. Worth recording for anyone else doing this work.

What is used instead: `ArtifactHandlerManager` — which *is* exported, recursively — plus `DefaultArtifact` constructed directly, which is what `MavenRepositorySystem.createArtifact` does internally.

### One behaviour change, and it needs a release note

`MavenMetadataSource.retrieveAvailableVersions` returned every version in `maven-metadata.xml`, snapshots included, and Maven's `VersionRange.containsVersion` accepts snapshots — so **a SNAPSHOT could win a version range**. Resolver's `DefaultVersionRangeResolver` requests `RELEASE`-nature metadata unless a bound of the range is itself a snapshot.

Concretely: for `[1.0,)` on an artifact with `2.2.0-SNAPSHOT` published, the Dependency Management report used to be able to render the snapshot's URL and licences; it now renders 2.1.0's. That aligns the report with how Maven's own dependency resolution treats ranges, so it reads as a fix — but it is user-visible.

Two things were deliberately held constant so the change stays on that one axis: the repository set is unchanged (`buildingRequest.getRemoteRepositories()` through `RepositoryUtils.toRepos`, so mirrors, auth and proxies come out exactly as core resolved them), and version *ordering* is unchanged (resolver `Version`s are converted back to `DefaultArtifactVersion` so Maven's comparator still picks the winner).

### Verification, and what it does not cover

`mvn verify` 30/30 and `-Prun-its` 22/22, identical on both sides, against a clean baseline worktree. Beyond counts: **all 529 generated HTML pages across the 22 ITs are byte-identical**, baseline versus migrated.

**The unit tests do not cover the changed path** — `DependencyManagementReportTest` pins a plain version, so the range branch is skipped. The `full-pom` IT does cover it, and its execution was confirmed from the build log rather than inferred:

```
Resolving range for DependencyManagement on org.apache.maven.doxia:doxia-sink-api:jar:[1.0,)
DependencyManagement resolved: org.apache.maven.doxia:doxia-sink-api:jar:2.1.0
```

**What is still not covered: a range whose matches include snapshots.** No fixture in the tree has one, so the behaviour change above is reasoned from the resolver's implementation plus a release-only IT — not observed. If that should be nailed down before merge, it needs a new IT with a snapshot repository.

Maven 4 was checked statically — every API used is present and exported in 4.0.0-rc-5 — but the ITs were not run against a Maven 4 install. Given how the `bridge` failure surfaced, I would not call Maven 4 proven without it.
