### PR TITLE
Migrate the site descriptor to the v2 model and implement getOutputPath()

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@ under the License.
     <doxiaVersion>2.1.0</doxiaVersion>
     <doxiaSitetoolsVersion>2.1.0</doxiaSitetoolsVersion>
     <scmVersion>2.2.1</scmVersion>
-    <fluidoSkinVersion>2.0.1</fluidoSkinVersion>
+    <fluidoSkinVersion>2.1.0</fluidoSkinVersion>
     <checkstyle.violation.ignore>ParameterNumber,MethodLength</checkstyle.violation.ignore>
     <project.build.outputTimestamp>2025-02-23T16:16:11Z</project.build.outputTimestamp>
   </properties>

--- a/src/main/java/org/apache/maven/report/projectinfo/CiManagementReport.java
+++ b/src/main/java/org/apache/maven/report/projectinfo/CiManagementReport.java
@@ -72,8 +72,20 @@ public class CiManagementReport extends AbstractProjectInfoReport {
         r.render();
     }
 
-    /** {@inheritDoc} */
+    /**
+     * @deprecated use {@link #getOutputPath()} instead
+     */
+    @Override
+    @Deprecated
     public String getOutputName() {
+        return getOutputPath();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getOutputPath() {
         return "ci-management";
     }
 

--- a/src/main/java/org/apache/maven/report/projectinfo/DependenciesReport.java
+++ b/src/main/java/org/apache/maven/report/projectinfo/DependenciesReport.java
@@ -160,9 +160,19 @@ public class DependenciesReport extends AbstractProjectInfoReport {
     }
 
     /**
+     * @deprecated use {@link #getOutputPath()} instead
+     */
+    @Override
+    @Deprecated
+    public String getOutputName() {
+        return getOutputPath();
+    }
+
+    /**
      * {@inheritDoc}
      */
-    public String getOutputName() {
+    @Override
+    public String getOutputPath() {
         return "dependencies";
     }
 

--- a/src/main/java/org/apache/maven/report/projectinfo/DependencyConvergenceReport.java
+++ b/src/main/java/org/apache/maven/report/projectinfo/DependencyConvergenceReport.java
@@ -112,9 +112,19 @@ public class DependencyConvergenceReport extends AbstractProjectInfoReport {
     // ----------------------------------------------------------------------
 
     /**
+     * @deprecated use {@link #getOutputPath()} instead
+     */
+    @Override
+    @Deprecated
+    public String getOutputName() {
+        return getOutputPath();
+    }
+
+    /**
      * {@inheritDoc}
      */
-    public String getOutputName() {
+    @Override
+    public String getOutputPath() {
         return "dependency-convergence";
     }
 

--- a/src/main/java/org/apache/maven/report/projectinfo/DependencyInformationReport.java
+++ b/src/main/java/org/apache/maven/report/projectinfo/DependencyInformationReport.java
@@ -65,9 +65,19 @@ public final class DependencyInformationReport extends AbstractProjectInfoReport
     // ----------------------------------------------------------------------
 
     /**
+     * @deprecated use {@link #getOutputPath()} instead
+     */
+    @Override
+    @Deprecated
+    public String getOutputName() {
+        return getOutputPath();
+    }
+
+    /**
      * {@inheritDoc}
      */
-    public String getOutputName() {
+    @Override
+    public String getOutputPath() {
         return "dependency-info";
     }
 

--- a/src/main/java/org/apache/maven/report/projectinfo/DependencyManagementReport.java
+++ b/src/main/java/org/apache/maven/report/projectinfo/DependencyManagementReport.java
@@ -103,10 +103,19 @@ public class DependencyManagementReport extends AbstractProjectInfoReport {
     }
 
     /**
+     * @deprecated use {@link #getOutputPath()} instead
+     */
+    @Override
+    @Deprecated
+    public String getOutputName() {
+        return getOutputPath();
+    }
+
+    /**
      * {@inheritDoc}
      */
     @Override
-    public String getOutputName() {
+    public String getOutputPath() {
         return "dependency-management";
     }
 

--- a/src/main/java/org/apache/maven/report/projectinfo/DistributionManagementReport.java
+++ b/src/main/java/org/apache/maven/report/projectinfo/DistributionManagementReport.java
@@ -67,8 +67,20 @@ public class DistributionManagementReport extends AbstractProjectInfoReport {
         r.render();
     }
 
-    /** {@inheritDoc} */
+    /**
+     * @deprecated use {@link #getOutputPath()} instead
+     */
+    @Override
+    @Deprecated
     public String getOutputName() {
+        return getOutputPath();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getOutputPath() {
         return "distribution-management";
     }
 

--- a/src/main/java/org/apache/maven/report/projectinfo/IndexReport.java
+++ b/src/main/java/org/apache/maven/report/projectinfo/IndexReport.java
@@ -88,8 +88,20 @@ public class IndexReport extends AbstractProjectInfoReport {
         r.render();
     }
 
-    /** {@inheritDoc} */
+    /**
+     * @deprecated use {@link #getOutputPath()} instead
+     */
+    @Override
+    @Deprecated
     public String getOutputName() {
+        return getOutputPath();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getOutputPath() {
         return "index";
     }
 

--- a/src/main/java/org/apache/maven/report/projectinfo/IssueManagementReport.java
+++ b/src/main/java/org/apache/maven/report/projectinfo/IssueManagementReport.java
@@ -66,8 +66,20 @@ public class IssueManagementReport extends AbstractProjectInfoReport {
         r.render();
     }
 
-    /** {@inheritDoc} */
+    /**
+     * @deprecated use {@link #getOutputPath()} instead
+     */
+    @Override
+    @Deprecated
     public String getOutputName() {
+        return getOutputPath();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getOutputPath() {
         return "issue-management";
     }
 

--- a/src/main/java/org/apache/maven/report/projectinfo/LicensesReport.java
+++ b/src/main/java/org/apache/maven/report/projectinfo/LicensesReport.java
@@ -137,9 +137,19 @@ public class LicensesReport extends AbstractProjectInfoReport {
     }
 
     /**
+     * @deprecated use {@link #getOutputPath()} instead
+     */
+    @Override
+    @Deprecated
+    public String getOutputName() {
+        return getOutputPath();
+    }
+
+    /**
      * {@inheritDoc}
      */
-    public String getOutputName() {
+    @Override
+    public String getOutputPath() {
         return "licenses";
     }
 

--- a/src/main/java/org/apache/maven/report/projectinfo/MailingListsReport.java
+++ b/src/main/java/org/apache/maven/report/projectinfo/MailingListsReport.java
@@ -74,9 +74,19 @@ public class MailingListsReport extends AbstractProjectInfoReport {
     }
 
     /**
+     * @deprecated use {@link #getOutputPath()} instead
+     */
+    @Override
+    @Deprecated
+    public String getOutputName() {
+        return getOutputPath();
+    }
+
+    /**
      * {@inheritDoc}
      */
-    public String getOutputName() {
+    @Override
+    public String getOutputPath() {
         return "mailing-lists";
     }
 

--- a/src/main/java/org/apache/maven/report/projectinfo/ModulesReport.java
+++ b/src/main/java/org/apache/maven/report/projectinfo/ModulesReport.java
@@ -86,8 +86,20 @@ public class ModulesReport extends AbstractProjectInfoReport {
                 .render();
     }
 
-    /** {@inheritDoc} */
+    /**
+     * @deprecated use {@link #getOutputPath()} instead
+     */
+    @Override
+    @Deprecated
     public String getOutputName() {
+        return getOutputPath();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getOutputPath() {
         return "modules";
     }
 

--- a/src/main/java/org/apache/maven/report/projectinfo/PluginManagementReport.java
+++ b/src/main/java/org/apache/maven/report/projectinfo/PluginManagementReport.java
@@ -101,8 +101,20 @@ public class PluginManagementReport extends AbstractProjectInfoReport {
         r.render();
     }
 
-    /** {@inheritDoc} */
+    /**
+     * @deprecated use {@link #getOutputPath()} instead
+     */
+    @Override
+    @Deprecated
     public String getOutputName() {
+        return getOutputPath();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getOutputPath() {
         return "plugin-management";
     }
 

--- a/src/main/java/org/apache/maven/report/projectinfo/PluginsReport.java
+++ b/src/main/java/org/apache/maven/report/projectinfo/PluginsReport.java
@@ -101,8 +101,20 @@ public class PluginsReport extends AbstractProjectInfoReport {
         r.render();
     }
 
-    /** {@inheritDoc} */
+    /**
+     * @deprecated use {@link #getOutputPath()} instead
+     */
+    @Override
+    @Deprecated
     public String getOutputName() {
+        return getOutputPath();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getOutputPath() {
         return "plugins";
     }
 

--- a/src/main/java/org/apache/maven/report/projectinfo/ScmReport.java
+++ b/src/main/java/org/apache/maven/report/projectinfo/ScmReport.java
@@ -145,8 +145,20 @@ public class ScmReport extends AbstractProjectInfoReport {
         r.render();
     }
 
-    /** {@inheritDoc} */
+    /**
+     * @deprecated use {@link #getOutputPath()} instead
+     */
+    @Override
+    @Deprecated
     public String getOutputName() {
+        return getOutputPath();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getOutputPath() {
         return "scm";
     }
 

--- a/src/main/java/org/apache/maven/report/projectinfo/SummaryReport.java
+++ b/src/main/java/org/apache/maven/report/projectinfo/SummaryReport.java
@@ -62,8 +62,20 @@ public class SummaryReport extends AbstractProjectInfoReport {
         new ProjectSummaryRenderer(getSink(), locale).render();
     }
 
-    /** {@inheritDoc} */
+    /**
+     * @deprecated use {@link #getOutputPath()} instead
+     */
+    @Override
+    @Deprecated
     public String getOutputName() {
+        return getOutputPath();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getOutputPath() {
         return "summary";
     }
 

--- a/src/main/java/org/apache/maven/report/projectinfo/TeamReport.java
+++ b/src/main/java/org/apache/maven/report/projectinfo/TeamReport.java
@@ -168,10 +168,19 @@ public class TeamReport extends AbstractProjectInfoReport {
     }
 
     /**
+     * @deprecated use {@link #getOutputPath()} instead
+     */
+    @Override
+    @Deprecated
+    public String getOutputName() {
+        return getOutputPath();
+    }
+
+    /**
      * {@inheritDoc}
      */
     @Override
-    public String getOutputName() {
+    public String getOutputPath() {
         return "team";
     }
 

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -19,8 +19,8 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-<project xmlns="http://maven.apache.org/DECORATION/1.8.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/DECORATION/1.8.1 https://maven.apache.org/xsd/decoration-1.8.1.xsd">
+<site xmlns="http://maven.apache.org/SITE/2.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/SITE/2.1.0 https://maven.apache.org/xsd/site-2.1.0.xsd">
   <body>
     <menu name="Overview">
       <item name="Introduction" href="index.html"/>
@@ -39,4 +39,4 @@ under the License.
       <item name="Customize Text Reports" href="examples/custom-report.html"/>
     </menu>
   </body>
-</project>
+</site>


### PR DESCRIPTION
Three parts of the Doxia 2 adoption that were still outstanding here.

- All 16 reports implement `getOutputPath()`, with `getOutputName()` kept as a deprecated delegate because Maven Reporting API 4.0.0 still declares it abstract — the pattern from the [report plugin guide](https://maven.apache.org/guides/plugin/guide-java-report-plugin-development.html), already used by maven-javadoc-plugin and maven-pmd-plugin. The output paths are unchanged strings.
- The site descriptor was still the v1 `<project xmlns=".../DECORATION/1.8.1">` model, which Doxia Sitetools warns "will break in the future". It carries only menus, so the conversion is the root element and the namespace.
- The ITs pinned Fluido Skin 2.0.1; 2.1.0 is released.

Verified: `mvn verify` → 30 tests, 0 failures; `mvn -Prun-its verify` → Passed: 24, Failed: 0 with the bumped skin. The descriptor validates against `site-2.1.0.xsd`.

*This change was created with AI assistance.*
